### PR TITLE
feat(group_theory): automate the construction of group instances on c…

### DIFF
--- a/algebra/group_power.lean
+++ b/algebra/group_power.lean
@@ -293,6 +293,17 @@ attribute [to_additive bit1_gsmul] gpow_bit1
 
 end group
 
+namespace is_group_hom
+variables {β : Type v} [group α] [group β] (f : α → β) [is_group_hom f]
+
+theorem pow (a : α) (n : ℕ) : f (a ^ n) = f a ^ n :=
+by induction n; simp [*, pow_succ, is_group_hom.mul f, is_group_hom.one f]
+
+theorem gpow (a : α) (n : ℤ) : f (a ^ n) = f a ^ n :=
+by cases n; simp [is_group_hom.pow f, is_group_hom.inv f]
+
+end is_group_hom
+
 local infix ` •ℤ `:70 := gsmul
 
 theorem add_monoid.smul_eq_mul' [semiring α] (a : α) : ∀ n : ℕ, n • a = a * n

--- a/algebra/pi_instances.lean
+++ b/algebra/pi_instances.lean
@@ -6,7 +6,7 @@ Authors: Simon Hudon, Patrick Massot
 Pi instances for algebraic structures.
 -/
 
-import algebra.module
+import algebra.module order.basic
 
 namespace tactic
 
@@ -42,78 +42,63 @@ variable {I : Type u}     -- The indexing type
 variable {f : I → Type v} -- The family of types already equiped with instances
 variables (x y : Π i, f i) (i : I)
 
-instance has_mul [∀ i, has_mul $ f i] : has_mul (Π i : I, f i) :=
-⟨λ x y, λ i, x i * y i⟩
-
-@[simp] lemma mul_apply [∀ i, has_mul $ f i] : (x * y) i = x i * y i := rfl
-
-instance semigroup [∀ i, semigroup $ f i] : semigroup (Π i : I, f i) :=
-by pi_instance
-
-instance comm_semigroup [∀ i, comm_semigroup $ f i] : comm_semigroup (Π i : I, f i) :=
-by pi_instance
-
-instance has_one [∀ i, has_one $ f i] : has_one (Π i : I, f i) :=
-⟨λ i, 1⟩
-
-@[simp] lemma one_apply [∀ i, has_one $ f i] : (1 : Π i, f i) i = 1 := rfl
-
-instance has_inv [∀ i, has_inv $ f i] : has_inv (Π i : I, f i) :=
-⟨λ x, λ i, (x i)⁻¹⟩
-
-@[simp] lemma inv_apply [∀ i, has_inv $ f i] : x⁻¹ i = (x i)⁻¹ := rfl
-
-instance monoid [∀ i, monoid $ f i] : monoid (Π i : I, f i) :=
-by pi_instance
-
-instance comm_monoid [∀ i, comm_monoid $ f i] : comm_monoid (Π i : I, f i) :=
-by pi_instance
-
-instance group [∀ i, group $ f i] : group (Π i : I, f i) :=
-by pi_instance
-
-instance has_add [∀ i, has_add $ f i] : has_add (Π i : I, f i) :=
-⟨λ x y, λ i, x i + y i⟩
-
-@[simp] lemma add_apply [∀ i, has_add $ f i] : (x + y) i = x i + y i := rfl
-
-instance add_semigroup [∀ i, add_semigroup $ f i] : add_semigroup (Π i : I, f i) :=
-by pi_instance
-
-instance has_zero [∀ i, has_zero $ f i] : has_zero (Π i : I, f i) :=
-⟨λ i, 0⟩
-
+instance has_zero [∀ i, has_zero $ f i] : has_zero (Π i : I, f i) := ⟨λ i, 0⟩
 @[simp] lemma zero_apply [∀ i, has_zero $ f i] : (0 : Π i, f i) i = 0 := rfl
 
-instance has_neg [∀ i, has_neg $ f i] : has_neg (Π i : I, f i) :=
-⟨λ x, λ i, -(x i)⟩
+instance has_one [∀ i, has_one $ f i] : has_one (Π i : I, f i) := ⟨λ i, 1⟩
+@[simp] lemma one_apply [∀ i, has_one $ f i] : (1 : Π i, f i) i = 1 := rfl
 
+instance has_add [∀ i, has_add $ f i] : has_add (Π i : I, f i) := ⟨λ x y, λ i, x i + y i⟩
+@[simp] lemma add_apply [∀ i, has_add $ f i] : (x + y) i = x i + y i := rfl
+
+instance has_mul [∀ i, has_mul $ f i] : has_mul (Π i : I, f i) := ⟨λ x y, λ i, x i * y i⟩
+@[simp] lemma mul_apply [∀ i, has_mul $ f i] : (x * y) i = x i * y i := rfl
+
+instance has_inv [∀ i, has_inv $ f i] : has_inv (Π i : I, f i) := ⟨λ x, λ i, (x i)⁻¹⟩
+@[simp] lemma inv_apply [∀ i, has_inv $ f i] : x⁻¹ i = (x i)⁻¹ := rfl
+
+instance has_neg [∀ i, has_neg $ f i] : has_neg (Π i : I, f i) := ⟨λ x, λ i, -(x i)⟩
 @[simp] lemma neg_apply [∀ i, has_neg $ f i] : (-x) i = -x i := rfl
 
-instance add_group [∀ i, add_group $ f i] : add_group (Π i : I, f i) :=
-by pi_instance
-
-instance add_comm_group [∀ i, add_comm_group $ f i] : add_comm_group (Π i : I, f i) :=
-by pi_instance
-
-instance distrib [∀ i, distrib $ f i] : distrib (Π i : I, f i) :=
-by pi_instance
-
-instance ring [∀ i, ring $ f i] : ring (Π i : I, f i) :=
-by pi_instance
-
-instance comm_ring [∀ i, comm_ring $ f i] : comm_ring (Π i : I, f i) :=
-by pi_instance
-
-instance has_scalar {α : Type*} [∀ i, has_scalar α $ f i] : has_scalar α (Π i : I, f i) :=
-⟨λ s x, λ i, s • (x i)⟩
-
+instance has_scalar {α : Type*} [∀ i, has_scalar α $ f i] : has_scalar α (Π i : I, f i) := ⟨λ s x, λ i, s • (x i)⟩
 @[simp] lemma smul_apply {α : Type*} [∀ i, has_scalar α $ f i] (s : α) : (s • x) i = s • x i := rfl
 
-instance module {α : Type*} [ring α] [∀ i, module α $ f i] : module α (Π i : I, f i) :=
-by pi_instance
+instance semigroup       [∀ i, semigroup       $ f i] : semigroup       (Π i : I, f i) := by pi_instance
+instance comm_semigroup  [∀ i, comm_semigroup  $ f i] : comm_semigroup  (Π i : I, f i) := by pi_instance
+instance monoid          [∀ i, monoid          $ f i] : monoid          (Π i : I, f i) := by pi_instance
+instance comm_monoid     [∀ i, comm_monoid     $ f i] : comm_monoid     (Π i : I, f i) := by pi_instance
+instance add_comm_monoid [∀ i, add_comm_monoid $ f i] : add_comm_monoid (Π i : I, f i) := by pi_instance
+instance group           [∀ i, group           $ f i] : group           (Π i : I, f i) := by pi_instance
+instance add_semigroup   [∀ i, add_semigroup   $ f i] : add_semigroup   (Π i : I, f i) := by pi_instance
+instance add_group       [∀ i, add_group       $ f i] : add_group       (Π i : I, f i) := by pi_instance
+instance add_comm_group  [∀ i, add_comm_group  $ f i] : add_comm_group  (Π i : I, f i) := by pi_instance
+instance ring            [∀ i, ring            $ f i] : ring            (Π i : I, f i) := by pi_instance
+instance comm_ring       [∀ i, comm_ring       $ f i] : comm_ring       (Π i : I, f i) := by pi_instance
+instance module {α} [ring α] [∀ i, module α    $ f i] : module α        (Π i : I, f i) := by pi_instance
 
-instance vector_space (α : Type*) [field α] [∀ i, vector_space α $ f i] : vector_space α (Π i : I, f i) :=
+instance vector_space (α) [field α] [∀ i, vector_space α $ f i] : vector_space α (Π i : I, f i) :=
 { ..pi.module }
+
+instance left_cancel_semigroup [∀ i, left_cancel_semigroup $ f i] : left_cancel_semigroup (Π i : I, f i) :=
+{ mul_left_cancel := λ a b c h, funext $ λ i, mul_left_cancel (congr_fun h i),
+  ..pi.semigroup }
+
+instance add_left_cancel_semigroup [∀ i, add_left_cancel_semigroup $ f i] : add_left_cancel_semigroup (Π i : I, f i) :=
+{ add_left_cancel := λ a b c h, funext $ λ i, add_left_cancel (congr_fun h i),
+  ..pi.add_semigroup }
+
+instance right_cancel_semigroup [∀ i, right_cancel_semigroup $ f i] : right_cancel_semigroup (Π i : I, f i) :=
+{ mul_right_cancel := λ a b c h, funext $ λ i, mul_right_cancel (congr_fun h i:_),
+  ..pi.semigroup }
+
+instance add_right_cancel_semigroup [∀ i, add_right_cancel_semigroup $ f i] : add_right_cancel_semigroup (Π i : I, f i) :=
+{ add_right_cancel := λ a b c h, funext $ λ i, add_right_cancel (congr_fun h i:_),
+  ..pi.add_semigroup }
+
+instance ordered_cancel_comm_monoid [∀ i, ordered_cancel_comm_monoid $ f i] : ordered_cancel_comm_monoid (Π i : I, f i) :=
+{ add_le_add_left := λ a b h c i, add_le_add_left' (h i),
+  le_of_add_le_add_left := λ a b c h i, le_of_add_le_add_left (h i),
+  ..pi.add_comm_monoid, ..pi.partial_order,
+  ..pi.add_left_cancel_semigroup, ..pi.add_right_cancel_semigroup }
 
 end pi

--- a/algebra/ring.lean
+++ b/algebra/ring.lean
@@ -34,6 +34,7 @@ instance [semiring α] : semiring (with_zero α) :=
   ..with_zero.mul_zero_class,
   ..with_zero.monoid }
 
+attribute [refl] dvd_refl
 attribute [trans] dvd.trans
 
 section

--- a/category/traversable/basic.lean
+++ b/category/traversable/basic.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2018 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Simon Hudon
+
+Type classes for traversing collections. The concepts and laws are taken from
+http://hackage.haskell.org/package/base-4.11.1.0/docs/Data-Traversable.html
+-/
+
+import tactic.cache
+import category.applicative
+
+open function (hiding comp)
+
+universes u v w
+
+section applicative_transformation
+
+variables (f : Type u → Type v) [applicative f] [is_lawful_applicative f]
+variables (g : Type u → Type w) [applicative g] [is_lawful_applicative g]
+
+structure applicative_transformation : Type (max (u+1) v w) :=
+(F : ∀ {α : Type u}, f α → g α)
+(preserves_pure' : ∀ {α : Type u} (x : α), F (pure x) = pure x)
+(preserves_seq' : ∀ {α β : Type u} (x : f (α → β)) (y : f α), F (x <*> y) = F x <*> F y)
+
+end applicative_transformation
+
+namespace applicative_transformation
+
+variables (f : Type u → Type v) [applicative f] [is_lawful_applicative f]
+variables (g : Type u → Type w) [applicative g] [is_lawful_applicative g]
+
+instance : has_coe_to_fun (applicative_transformation f g) :=
+{ F := λ _, ∀ {α}, f α → g α,
+  coe := λ m, m.F }
+
+variables {f g}
+variables (η : applicative_transformation f g)
+
+@[functor_norm]
+lemma preserves_pure :
+  ∀ {α : Type u} (x : α), η (pure x) = pure x :=
+by apply applicative_transformation.preserves_pure'
+
+@[functor_norm]
+lemma preserves_seq :
+  ∀ {α β : Type u} (x : f (α → β)) (y : f α), η (x <*> y) = η x <*> η y :=
+by apply applicative_transformation.preserves_seq'
+
+@[functor_norm]
+lemma preserves_map {α β : Type u} (x : α → β)  (y : f α) :
+  η (x <$> y) = x <$> η y :=
+by rw [← pure_seq_eq_map,η.preserves_seq]; simp with functor_norm
+
+end applicative_transformation
+
+open applicative_transformation
+
+class traversable (t : Type u → Type u) extends functor t :=
+(traverse : Π {m : Type u → Type u} [applicative m]
+   {α β : Type u},
+   (α → m β) → t α → m (t β))
+
+open functor
+
+export traversable (traverse)
+
+section functions
+
+variables {t : Type u → Type u}
+variables {m : Type u → Type v} [applicative m]
+variables {α β : Type u}
+
+
+variables {f : Type u → Type u} [applicative f]
+
+def sequence [traversable t] :
+  t (f α) → f (t α) :=
+traverse id
+
+end functions
+
+class is_lawful_traversable (t : Type u → Type u) [traversable t]
+extends is_lawful_functor t :
+  Type (u+1) :=
+(id_traverse : ∀ {α : Type u} (x : t α), traverse id.mk x = x )
+(comp_traverse : ∀ {G H : Type u → Type u}
+               [applicative G] [applicative H]
+               [is_lawful_applicative G] [is_lawful_applicative H]
+               {α β γ : Type u}
+               (g : α → G β) (h : β → H γ) (x : t α),
+   traverse (comp.mk ∘ map h ∘ g) x =
+   comp.mk (map (traverse h) (traverse g x)))
+(map_traverse : ∀ {G : Type u → Type u}
+               [applicative G] [is_lawful_applicative G]
+               {α β γ : Type u}
+               (g : α → G β) (h : β → γ)
+               (x : t α),
+               map (map h) (traverse g x) =
+               traverse (map h ∘ g) x)
+(traverse_map : ∀ {G : Type u → Type u}
+               [applicative G] [is_lawful_applicative G]
+               {α β γ : Type u}
+               (g : α → β) (h : β → G γ)
+               (x : t α),
+               traverse h (map g x) =
+               traverse (h ∘ g) x)
+(naturality : ∀ {G H : Type u → Type u}
+                [applicative G] [applicative H]
+                [is_lawful_applicative G] [is_lawful_applicative H]
+                (η : applicative_transformation G H),
+                ∀ {α β : Type u} (f : α → G β) (x : t α),
+                  η (traverse f x) = traverse (@η _ ∘ f) x)

--- a/category/traversable/default.lean
+++ b/category/traversable/default.lean
@@ -1,0 +1,3 @@
+import category.traversable.basic
+       category.traversable.instances
+       category.traversable.lemmas

--- a/category/traversable/instances.lean
+++ b/category/traversable/instances.lean
@@ -1,0 +1,255 @@
+/-
+Copyright (c) 2018 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Simon Hudon
+
+Instances of `traversable` for types from the core library
+-/
+
+import category.traversable.basic
+import category.basic
+import category.functor
+import category.applicative
+
+universes u v
+
+open function
+
+section identity
+
+open function functor
+
+variables {f f' : Type u → Type u}
+variables [applicative f] [applicative f']
+
+
+instance : traversable id :=
+⟨ λ _ _ _ _, id ⟩
+
+variables [is_lawful_applicative f] [is_lawful_applicative f']
+
+lemma id.id_traverse {α : Type*} (x : id α) :
+  traverse id.mk x = x :=
+rfl
+
+lemma id.comp_traverse {α β γ : Type*} (g : α → f β) (h : β → f' γ) (x : id α) :
+  traverse (comp.mk ∘ (<$>) h ∘ g) x =
+  comp.mk (traverse h <$> traverse g x) :=
+by simp! [traverse,functor.map_id] with functor_norm
+
+lemma id.map_traverse {α β γ : Type*}
+   (g : α → f' β) (f : β → γ)
+   (x : id α) :
+  (<$>) f <$> traverse g x = traverse ((<$>) f ∘ g) x :=
+by simp [(<$>),id_bind,traverse] with functor_norm
+
+lemma id.traverse_map {α β γ : Type*}
+   (g : α → β) (f : β → f' γ)
+   (x : id α) :
+  traverse f (g <$> x) = traverse (f ∘ g) x :=
+by simp [(<$>),id_bind,traverse] with functor_norm
+
+variable (η : applicative_transformation f f')
+
+lemma id.naturality {α β : Type*}
+  (F : α → f β) (x : id α) :
+  η (traverse F x) = traverse (@η _ ∘ F) x :=
+by simp! [traverse] with functor_norm; refl
+
+end identity
+
+instance : is_lawful_traversable id :=
+{ id_traverse := λ α x, @id.id_traverse α x,
+  comp_traverse := @id.comp_traverse,
+  map_traverse := @id.map_traverse,
+  traverse_map := @id.traverse_map,
+  naturality := @id.naturality }
+
+section option
+
+open function functor
+
+section inst
+
+variables {f : Type u → Type v}
+variables [applicative f]
+
+protected def option.traverse {α β : Type*} (g : α → f β) : option α → f (option β)
+| none := pure none
+| (some x) := some <$> g x
+
+instance : traversable option :=
+{ traverse := @option.traverse }
+
+end inst
+
+variables {f f' : Type u → Type u}
+variables [applicative f] [applicative f']
+
+variables [is_lawful_applicative f] [is_lawful_applicative f']
+
+lemma option.id_traverse {α : Type*} (x : option α) :
+  option.traverse id.mk x = x :=
+by cases x; unfold option.traverse; refl
+
+lemma option.comp_traverse {α β γ : Type*} (g : α → f β) (h : β → f' γ) :
+  ∀ (x : option α),
+        option.traverse (comp.mk ∘ (<$>) h ∘ g) x =
+        comp.mk (option.traverse h <$> option.traverse g x) :=
+by intro x; cases x; simp! with functor_norm; refl
+
+lemma option.map_traverse {α β γ : Type*} (g : α -> f β) (h : β → γ)
+  (x : option α) :
+  option.map h <$> option.traverse g x = option.traverse ((<$>) h ∘ g) x :=
+by cases x; simp! with functor_norm; refl
+
+lemma option.traverse_map {α β γ : Type*} (g : α -> β) (f : β → f' γ)
+  (x : option α) :
+  option.traverse f (g <$> x) = option.traverse (f ∘ g) x :=
+by cases x; simp! with functor_norm; refl
+
+variable (η : applicative_transformation f f')
+
+lemma option.naturality {α β : Type*} (g : α → f β) (x : option α) :
+  η (option.traverse g x) = option.traverse (@η _ ∘ g) x :=
+by cases x with x; simp! [*] with functor_norm
+
+end option
+
+instance : is_lawful_traversable option :=
+{ id_traverse := @option.id_traverse,
+  comp_traverse := @option.comp_traverse,
+  map_traverse := @option.map_traverse,
+  traverse_map := @option.traverse_map,
+  naturality := @option.naturality }
+
+section list
+
+variables {f : Type u → Type v}
+variables [applicative f]
+
+open applicative functor
+open list (cons)
+
+protected def list.traverse {α β : Type*} (g : α → f β) : list α → f (list β)
+| [] := pure []
+| (x :: xs) := cons <$> g x <*> list.traverse xs
+
+end list
+
+section list
+
+variables {f f' : Type u → Type u}
+variables [applicative f] [applicative f']
+variables [is_lawful_applicative f] [is_lawful_applicative f']
+
+open applicative functor
+open list (cons)
+
+lemma list.id_traverse {α : Type*}
+  (xs : list α) :
+  list.traverse id.mk xs = xs :=
+by induction xs; simp! [*] with functor_norm; refl
+
+lemma list.comp_traverse {α β γ : Type*}
+  (g : α → f β) (h : β → f' γ) (x : list α) :
+  list.traverse (comp.mk ∘ (<$>) h ∘ g) x =
+  comp.mk (list.traverse h <$> list.traverse g x) :=
+by induction x; simp! [*] with functor_norm; refl
+
+lemma list.map_traverse {α β γ : Type*}
+  (g : α → f' β) (f : β → γ)
+  (x : list α) :
+  (<$>) f <$> list.traverse g x = list.traverse ((<$>) f ∘ g) x :=
+begin
+  symmetry,
+  induction x with x xs ih;
+  simp! [*] with functor_norm; refl
+end
+
+lemma list.traverse_map {α β γ : Type*}
+  (g : α → β) (f : β → f' γ)
+  (x : list α) :
+  list.traverse f (g <$> x) = list.traverse (f ∘ g) x :=
+begin
+  symmetry,
+  induction x with x xs ih;
+  simp! [*] with functor_norm; refl
+end
+
+variable (η : applicative_transformation f f')
+
+lemma list.naturality {α β : Type*} (g : α → f β) (x : list α) :
+  η (list.traverse g x) = list.traverse (@η _ ∘ g) x :=
+by induction x; simp! [*] with functor_norm
+open nat
+
+end list
+
+instance : traversable list :=
+{ traverse := @list.traverse }
+
+instance : is_lawful_traversable list :=
+{ id_traverse := @list.id_traverse,
+  comp_traverse := @list.comp_traverse,
+  map_traverse := @list.map_traverse,
+  traverse_map := @list.traverse_map,
+  naturality := @list.naturality }
+
+namespace sum
+
+section traverse
+variables {γ : Type u}
+variables {f f' : Type u → Type u}
+variables [applicative f] [applicative f']
+
+open applicative functor
+open list (cons)
+
+protected def traverse {α β : Type*} (g : α → f β) : γ ⊕ α → f (γ ⊕ β)
+| (sum.inl x) := pure (sum.inl x)
+| (sum.inr x) := sum.inr <$> g x
+
+variables [is_lawful_applicative f] [is_lawful_applicative f']
+
+protected lemma id_traverse {φ α : Type*} (x : φ ⊕ α) :
+  sum.traverse id.mk x = x :=
+by cases x; refl
+
+protected lemma comp_traverse {α β φ : Type*} (g : α → f β) (h : β → f' φ) (x : γ ⊕ α) :
+        sum.traverse (comp.mk ∘ (<$>) h ∘ g) x =
+        comp.mk (sum.traverse h <$> sum.traverse g x) :=
+by casesm _ ⊕ _; simp! [sum.traverse,map_id] with functor_norm; refl
+
+protected lemma map_traverse {α β φ : Type*}
+   (g : α → f' β) (f : β → φ)
+   (x : γ ⊕ α) :
+  (<$>) f <$> sum.traverse g x = sum.traverse ((<$>) f ∘ g) x :=
+by casesm _ ⊕ _; simp [(<$>),sum.mapr,sum.traverse,id_map] with functor_norm; congr
+
+protected lemma traverse_map {α : Type u} {β φ : Type*}
+   (g : α → β) (f : β → f' φ)
+   (x : γ ⊕ α) :
+  sum.traverse f (g <$> x) = sum.traverse (f ∘ g) x :=
+by casesm _ ⊕ _; simp [(<$>),sum.mapr,sum.traverse,id_map] with functor_norm
+
+variable (η : applicative_transformation f f')
+
+protected lemma naturality {α β : Type*}
+  (F : α → f β) (x : γ ⊕ α) :
+  η (sum.traverse F x) = sum.traverse (@η _ ∘ F) x :=
+by cases x; simp! [sum.traverse] with functor_norm; refl
+
+end traverse
+
+instance {γ : Type u} : traversable.{u} (sum γ) :=
+{ traverse := @sum.traverse.{u} γ }
+
+instance {γ : Type u} : is_lawful_traversable.{u} (sum γ) :=
+{ id_traverse := @sum.id_traverse γ,
+  comp_traverse := @sum.comp_traverse γ,
+  map_traverse := @sum.map_traverse γ,
+  traverse_map := @sum.traverse_map γ,
+  naturality := @sum.naturality γ }
+
+end sum

--- a/category/traversable/lemmas.lean
+++ b/category/traversable/lemmas.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2018 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Simon Hudon
+
+Lemmas about traversing collections.
+
+Inspired by:
+
+    The Essence of the Iterator Pattern
+    Jeremy Gibbons and Bruno César dos Santos Oliveira
+    In Journal of Functional Programming. Vol. 19. No. 3&4. Pages 377−402. 2009.
+    http://www.cs.ox.ac.uk/jeremy.gibbons/publications/iterator.pdf
+-/
+
+import tactic.cache
+import category.traversable.basic
+
+universe variables u
+
+open is_lawful_traversable
+open function (hiding comp)
+open functor
+
+attribute [functor_norm] is_lawful_traversable.naturality
+
+namespace traversable
+
+variable {t : Type u → Type u}
+variables [traversable t] [is_lawful_traversable t]
+variables {G H : Type u → Type u}
+
+variables [applicative G] [is_lawful_applicative G]
+variables [applicative H] [is_lawful_applicative H]
+variables {α β γ : Type u}
+variables g : α → G β
+variables h : β → H γ
+variables f : β → γ
+
+variables G H
+
+def pure_transformation : applicative_transformation id G :=
+begin
+  refine { F := @pure G _, .. }; intros,
+  { refl },
+  { simp, refl }
+end
+
+variables {G H}
+
+lemma traverse_eq_map_ident (x : t β) :
+  traverse (id.mk ∘ f) x = id.mk (f <$> x) :=
+calc
+      traverse (id.mk ∘ f) x
+    = traverse id.mk (f <$> x) : by rw [← traverse_map]
+... = (<$>) f <$> x            : by simp [id_traverse]; refl
+
+lemma purity (x : t α) :
+  traverse pure x = (pure x : G (t α)) :=
+let η := pure_transformation G in
+calc   traverse (@pure G _ _) x
+     = traverse (pure ∘ id.mk) x : rfl
+ ... = traverse (@η _ ∘ id.mk) x : rfl
+ ... = η (traverse id.mk x)      : by rw [naturality]
+ ... = η x                       : by rw [id_traverse]
+ ... = pure x                    : rfl
+
+lemma id_sequence (x : t α) :
+  sequence (id.mk <$> x) = id.mk x :=
+by simp [sequence,traverse_map,id_traverse]; refl
+
+lemma comp_sequence (x : t (G (H α))) :
+  sequence (comp.mk <$> x) = comp.mk (sequence <$> sequence x) :=
+by simp [sequence,traverse_map]; rw ← comp_traverse; simp [map_id]
+
+lemma naturality' (η : applicative_transformation G H) (x : t (G α)) :
+  η (sequence x) = sequence (@η _ <$> x) :=
+by simp [sequence,naturality,traverse_map]
+
+end traversable

--- a/data/fin.lean
+++ b/data/fin.lean
@@ -18,6 +18,18 @@ by cases j; simp [fin.succ]
 @[simp] lemma pred_val (j : fin (n+1)) (h : j ≠ 0) : (j.pred h).val = j.val.pred :=
 by cases j; simp [fin.pred]
 
+@[simp] protected lemma eta (a : fin n) (h : a.1 < n) : (⟨a.1, h⟩ : fin n) = a :=
+by cases a; refl
+
+instance {n : ℕ} : linear_order (fin n) :=
+{ le_refl := λ a, @le_refl ℕ _ _,
+  le_trans := λ a b c, @le_trans ℕ _ _ _ _,
+  le_antisymm := λ a b ha hb, fin.eq_of_veq $ le_antisymm ha hb,
+  le_total := λ a b, @le_total ℕ _ _ _,
+  lt_iff_le_not_le := λ a b, @lt_iff_le_not_le ℕ _ _ _,
+  ..fin.has_le,
+  ..fin.has_lt }
+
 end fin
 
 theorem eq_of_lt_succ_of_not_lt {a b : ℕ} (h1 : a < b + 1) (h2 : ¬ a < b) : a = b :=

--- a/data/list/basic.lean
+++ b/data/list/basic.lean
@@ -2935,7 +2935,7 @@ inductive pairwise : list α → Prop
 | cons : ∀ {a : α} {l : list α}, (∀ a' ∈ l, R a a') → pairwise l → pairwise (a::l)
 attribute [simp] pairwise.nil
 
-run_cmd tactic.mk_iff_of_inductive_prop `list.pairwise `list.pariwise_iff
+run_cmd tactic.mk_iff_of_inductive_prop `list.pairwise `list.pairwise_iff
 
 variable {R}
 @[simp] theorem pairwise_cons {a : α} {l : list α} :

--- a/data/nat/basic.lean
+++ b/data/nat/basic.lean
@@ -375,6 +375,10 @@ by induction n; simp [*, pow_succ, mul_assoc]
 theorem pow_dvd_pow (a : ℕ) {m n : ℕ} (h : m ≤ n) : a^m ∣ a^n :=
 by rw [← nat.add_sub_cancel' h, pow_add]; apply dvd_mul_right
 
+theorem pow_dvd_pow_of_dvd {a b : ℕ} (h : a ∣ b) : ∀ n:ℕ, a^n ∣ b^n
+| 0     := dvd_refl _
+| (n+1) := mul_dvd_mul (pow_dvd_pow_of_dvd n) h
+
 theorem mul_pow (a b n : ℕ) : (a * b) ^ n = a ^ n * b ^ n := 
 by induction n; simp [*, nat.pow_succ, mul_comm, mul_assoc, mul_left_comm]
 

--- a/data/nat/basic.lean
+++ b/data/nat/basic.lean
@@ -375,6 +375,9 @@ by induction n; simp [*, pow_succ, mul_assoc]
 theorem pow_dvd_pow (a : ℕ) {m n : ℕ} (h : m ≤ n) : a^m ∣ a^n :=
 by rw [← nat.add_sub_cancel' h, pow_add]; apply dvd_mul_right
 
+theorem mul_pow (a b n : ℕ) : (a * b) ^ n = a ^ n * b ^ n := 
+by induction n; simp [*, nat.pow_succ, mul_comm, mul_assoc, mul_left_comm]
+
 @[simp] theorem bodd_div2_eq (n : ℕ) : bodd_div2 n = (bodd n, div2 n) :=
 by unfold bodd div2; cases bodd_div2 n; refl
 

--- a/data/nat/gcd.lean
+++ b/data/nat/gcd.lean
@@ -245,10 +245,14 @@ theorem not_coprime_of_dvd_of_dvd {m n d : ℕ} (dgt1 : d > 1) (Hm : d ∣ m) (H
 not_lt_of_ge (le_of_dvd zero_lt_one $ by rw ←co; exact dvd_gcd Hm Hn) dgt1
 
 theorem exists_coprime {m n : ℕ} (H : gcd m n > 0) :
-  exists m' n', coprime m' n' ∧ m = m' * gcd m n ∧ n = n' * gcd m n :=
+  ∃ m' n', coprime m' n' ∧ m = m' * gcd m n ∧ n = n' * gcd m n :=
 ⟨_, _, coprime_div_gcd_div_gcd H,
   (nat.div_mul_cancel (gcd_dvd_left m n)).symm,
   (nat.div_mul_cancel (gcd_dvd_right m n)).symm⟩
+
+theorem exists_coprime' {m n : ℕ} (H : gcd m n > 0) :
+  ∃ g m' n', 0 < g ∧ coprime m' n' ∧ m = m' * g ∧ n = n' * g :=
+let ⟨m', n', h⟩ := exists_coprime H in ⟨_, m', n', H, h⟩
 
 theorem coprime.mul {m n k : ℕ} (H1 : coprime m k) (H2 : coprime n k) : coprime (m * n) k :=
 (H1.gcd_mul_left_cancel n).trans H2
@@ -290,7 +294,7 @@ theorem coprime.pow {k l : ℕ} (m n : ℕ) (H1 : coprime k l) : coprime (k ^ m)
 theorem coprime.eq_one_of_dvd {k m : ℕ} (H : coprime k m) (d : k ∣ m) : k = 1 :=
 by rw [← H.gcd_eq_one, gcd_eq_left d]
 
-theorem exists_eq_prod_and_dvd_and_dvd {m n k : nat} (H : k ∣ m * n) :
+theorem exists_eq_prod_and_dvd_and_dvd {m n k : ℕ} (H : k ∣ m * n) :
   ∃ m' n', k = m' * n' ∧ m' ∣ m ∧ n' ∣ n :=
 or.elim (eq_zero_or_pos (gcd k m))
   (λg0, ⟨0, n,
@@ -305,11 +309,10 @@ theorem pow_dvd_pow_iff {a b n : ℕ} (n0 : 0 < n) : a ^ n ∣ b ^ n ↔ a ∣ b
 begin
   refine ⟨λ h, _, λ h, pow_dvd_pow_of_dvd h _⟩,
   cases eq_zero_or_pos (gcd a b) with g0 g0,
-  { simp [eq_zero_of_gcd_eq_zero_right g0, dvd_zero] },
-  rcases exists_coprime g0 with ⟨a', b', co, h₁, h₂⟩,
-  generalize_hyp : gcd a b = g at g0 h₁ h₂, substs a b,
+  { simp [eq_zero_of_gcd_eq_zero_right g0] },
+  rcases exists_coprime' g0 with ⟨g, a', b', g0', co, rfl, rfl⟩,
   rw [mul_pow, mul_pow] at h,
-  replace h := dvd_of_mul_dvd_mul_right (pos_pow_of_pos _ g0) h,
+  replace h := dvd_of_mul_dvd_mul_right (pos_pow_of_pos _ g0') h,
   have := pow_dvd_pow a' n0,
   rw [pow_one, (co.pow n n).eq_one_of_dvd h] at this,
   simp [eq_one_of_dvd_one this]

--- a/data/nat/gcd.lean
+++ b/data/nat/gcd.lean
@@ -301,4 +301,32 @@ or.elim (eq_zero_or_pos (gcd k m))
     dvd_of_mul_dvd_mul_left gpos $ by rw [←hd, ←gcd_mul_right]; exact
       dvd_gcd (dvd_mul_right _ _) H⟩)
 
+lemma dvd_of_pow_dvd_pow : ∀ {a b n : ℕ}, 0 < n → a ^ n ∣ b ^ n → a ∣ b
+| a 0     := λ n hn h, dvd_zero _
+| a (b+1) := λ n hn h,
+let d := nat.gcd a (b + 1) in
+have hd : nat.gcd a (b + 1) = d := rfl,
+  match d, hd with
+  | 0 := λ hd, (eq_zero_of_gcd_eq_zero_right hd).symm ▸ dvd_zero _
+  | 1 := λ hd,
+    begin
+      have h₁ : a ^ n = 1 := coprime.eq_one_of_dvd (coprime.pow n n hd) h,
+      have := pow_dvd_pow a hn,
+      rw [nat.pow_one, h₁] at this,
+      exact dvd.trans this (one_dvd _),
+    end
+  | (d+2) := λ hd,
+    have (b+1) / (d+2) < (b+1) := div_lt_self dec_trivial dec_trivial,
+    have ha : a = (d+2) * (a / (d+2)) :=
+      by rw [← hd, nat.mul_div_cancel' (gcd_dvd_left _ _)],
+    have hb : (b+1) = (d+2) * ((b+1) / (d+2)) :=
+      by rw [← hd, nat.mul_div_cancel' (gcd_dvd_right _ _)],
+    have a / (d+2) ∣ (b+1) / (d+2) := dvd_of_pow_dvd_pow hn $ dvd_of_mul_dvd_mul_left
+      (show (d + 2) ^ n > 0, from pos_pow_of_pos _ dec_trivial)
+      (by rwa [← nat.mul_pow, ← nat.mul_pow, ← ha, ← hb]),
+    by rw [ha, hb];
+    exact mul_dvd_mul_left _ this
+  end
+using_well_founded {rel_tac := λ _ _, `[exact ⟨_, measure_wf psigma.snd⟩]}
+
 end nat

--- a/data/nat/gcd.lean
+++ b/data/nat/gcd.lean
@@ -301,32 +301,18 @@ or.elim (eq_zero_or_pos (gcd k m))
     dvd_of_mul_dvd_mul_left gpos $ by rw [←hd, ←gcd_mul_right]; exact
       dvd_gcd (dvd_mul_right _ _) H⟩)
 
-lemma dvd_of_pow_dvd_pow : ∀ {a b n : ℕ}, 0 < n → a ^ n ∣ b ^ n → a ∣ b
-| a 0     := λ n hn h, dvd_zero _
-| a (b+1) := λ n hn h,
-let d := nat.gcd a (b + 1) in
-have hd : nat.gcd a (b + 1) = d := rfl,
-  match d, hd with
-  | 0 := λ hd, (eq_zero_of_gcd_eq_zero_right hd).symm ▸ dvd_zero _
-  | 1 := λ hd,
-    begin
-      have h₁ : a ^ n = 1 := coprime.eq_one_of_dvd (coprime.pow n n hd) h,
-      have := pow_dvd_pow a hn,
-      rw [nat.pow_one, h₁] at this,
-      exact dvd.trans this (one_dvd _),
-    end
-  | (d+2) := λ hd,
-    have (b+1) / (d+2) < (b+1) := div_lt_self dec_trivial dec_trivial,
-    have ha : a = (d+2) * (a / (d+2)) :=
-      by rw [← hd, nat.mul_div_cancel' (gcd_dvd_left _ _)],
-    have hb : (b+1) = (d+2) * ((b+1) / (d+2)) :=
-      by rw [← hd, nat.mul_div_cancel' (gcd_dvd_right _ _)],
-    have a / (d+2) ∣ (b+1) / (d+2) := dvd_of_pow_dvd_pow hn $ dvd_of_mul_dvd_mul_left
-      (show (d + 2) ^ n > 0, from pos_pow_of_pos _ dec_trivial)
-      (by rwa [← nat.mul_pow, ← nat.mul_pow, ← ha, ← hb]),
-    by rw [ha, hb];
-    exact mul_dvd_mul_left _ this
-  end
-using_well_founded {rel_tac := λ _ _, `[exact ⟨_, measure_wf psigma.snd⟩]}
+theorem pow_dvd_pow_iff {a b n : ℕ} (n0 : 0 < n) : a ^ n ∣ b ^ n ↔ a ∣ b :=
+begin
+  refine ⟨λ h, _, λ h, pow_dvd_pow_of_dvd h _⟩,
+  cases eq_zero_or_pos (gcd a b) with g0 g0,
+  { simp [eq_zero_of_gcd_eq_zero_right g0, dvd_zero] },
+  rcases exists_coprime g0 with ⟨a', b', co, h₁, h₂⟩,
+  generalize_hyp : gcd a b = g at g0 h₁ h₂, substs a b,
+  rw [mul_pow, mul_pow] at h,
+  replace h := dvd_of_mul_dvd_mul_right (pos_pow_of_pos _ g0) h,
+  have := pow_dvd_pow a' n0,
+  rw [pow_one, (co.pow n n).eq_one_of_dvd h] at this,
+  simp [eq_one_of_dvd_one this]
+end
 
 end nat

--- a/data/nat/prime.lean
+++ b/data/nat/prime.lean
@@ -80,6 +80,10 @@ theorem dvd_prime_ge_two {p m : ℕ} (pp : prime p) (H : m ≥ 2) : m ∣ p ↔ 
 theorem prime.not_dvd_one {p : ℕ} (pp : prime p) : ¬ p ∣ 1
 | d := (not_le_of_gt pp.gt_one) $ le_of_dvd dec_trivial d
 
+theorem not_prime_mul {a b : ℕ} (a1 : 1 < a) (b1 : 1 < b) : ¬ prime (a * b) :=
+λ h, ne_of_lt (nat.mul_lt_mul_of_pos_left b1 (lt_of_succ_lt a1)) $
+by simpa using (dvd_prime_ge_two h a1).1 (dvd_mul_right _ _)
+
 section min_fac
   private lemma min_fac_lemma (n k : ℕ) (h : ¬ k * k > n) :
     sqrt n - k < sqrt n + 2 - k :=
@@ -103,11 +107,13 @@ section min_fac
   @[simp] theorem min_fac_zero : min_fac 0 = 2 := rfl
   @[simp] theorem min_fac_one : min_fac 1 = 1 := rfl
 
-  theorem min_fac_eq : ∀ {n : ℕ} (n2 : n ≥ 2),
-    min_fac n = if 2 ∣ n then 2 else min_fac_aux n 3
-  | 1     h := (dec_trivial : ¬ _).elim h
-  | (n+2) h := by by_cases 2 ∣ n;
-    simp [min_fac, (nat.dvd_add_iff_left (dvd_refl 2)).symm, h]
+  theorem min_fac_eq : ∀ n, min_fac n = if 2 ∣ n then 2 else min_fac_aux n 3
+  | 0     := rfl
+  | 1     := by simp [show 2≠1, from dec_trivial]; rw min_fac_aux; refl
+  | (n+2) :=
+    have 2 ∣ n + 2 ↔ 2 ∣ n, from
+      (nat.dvd_add_iff_left (by refl)).symm,
+    by simp [min_fac, this]; congr
 
   private def min_fac_prop (n k : ℕ) :=
     k ≥ 2 ∧ k ∣ n ∧ ∀ m ≥ 2, m ∣ n → k ≤ m
@@ -142,7 +148,7 @@ section min_fac
   begin
     by_cases n0 : n = 0, {simp [n0, min_fac_prop, ge]},
     have n2 : 2 ≤ n, { revert n0 n1, rcases n with _|_|_; exact dec_trivial },
-    simp [min_fac_eq n2],
+    simp [min_fac_eq],
     by_cases d2 : 2 ∣ n; simp [d2],
     { exact ⟨le_refl _, d2, λ k k2 d, k2⟩ },
     { refine min_fac_aux_has_prop n2 d2 3 0 rfl
@@ -158,7 +164,7 @@ section min_fac
   let ⟨f2, fd, a⟩ := min_fac_has_prop n1 in
   prime_def_lt'.2 ⟨f2, λ m m2 l d, not_le_of_gt l (a m m2 (dvd_trans d fd))⟩
 
-  theorem min_fac_le_of_dvd (n : ℕ) : ∀ (m : ℕ), m ≥ 2 → m ∣ n → min_fac n ≤ m :=
+  theorem min_fac_le_of_dvd {n : ℕ} : ∀ {m : ℕ}, m ≥ 2 → m ∣ n → min_fac n ≤ m :=
   by by_cases n1 : n = 1;
     [exact λ m m2 d, n1.symm ▸ le_trans dec_trivial m2,
      exact (min_fac_has_prop n1).2.2]

--- a/data/quot.lean
+++ b/data/quot.lean
@@ -167,3 +167,56 @@ end trunc
 
 theorem nonempty_of_trunc (q : trunc α) : nonempty α :=
 let ⟨a, _⟩ := q.exists_rep in ⟨a⟩
+
+namespace quotient
+variables {γ : Sort*} {φ : Sort*} 
+  {s₁ : setoid α} {s₂ : setoid β} {s₃ : setoid γ}
+
+/- Versions of quotient definitions and lemmas ending in `'` use unification instead
+of typeclass inference for inferring the `setoid` argument. This is useful when there are
+several different quotient relations on a type, for example quotient groups, rings and modules -/
+
+protected def mk' (a : α) : quotient s₁ := quot.mk s₁.1 a
+
+@[elab_as_eliminator, reducible]
+protected def lift_on' (q : quotient s₁) (f : α → φ) 
+  (h : ∀ a b, @setoid.r α s₁ a b → f a = f b) : φ := quotient.lift_on q f h
+
+@[elab_as_eliminator, reducible]
+protected def lift_on₂' (q₁ : quotient s₁) (q₂ : quotient s₂) (f : α → β → γ)
+  (h : ∀ a₁ a₂ b₁ b₂, @setoid.r α s₁ a₁ b₁ → @setoid.r β s₂ a₂ b₂ → f a₁ a₂ = f b₁ b₂) : γ :=
+quotient.lift_on₂ q₁ q₂ f h
+
+@[elab_as_eliminator]
+protected lemma induction_on' {p : quotient s₁ → Prop} (q : quotient s₁)
+  (h : ∀ a, p (quotient.mk' a)) : p q := quotient.induction_on q h
+
+@[elab_as_eliminator]
+protected lemma induction_on₂' {p : quotient s₁ → quotient s₂ → Prop} (q₁ : quotient s₁)
+  (q₂ : quotient s₂) (h : ∀ a₁ a₂, p (quotient.mk' a₁) (quotient.mk' a₂)) : p q₁ q₂ :=
+quotient.induction_on₂ q₁ q₂ h
+
+@[elab_as_eliminator]
+protected lemma induction_on₃' {p : quotient s₁ → quotient s₂ → quotient s₃ → Prop} 
+  (q₁ : quotient s₁) (q₂ : quotient s₂) (q₃ : quotient s₃) 
+  (h : ∀ a₁ a₂ a₃, p (quotient.mk' a₁) (quotient.mk' a₂) (quotient.mk' a₃)) : p q₁ q₂ q₃ :=
+quotient.induction_on₃ q₁ q₂ q₃ h
+
+lemma exact' {a b : α} : 
+  (quotient.mk' a : quotient s₁) = quotient.mk' b → @setoid.r _ s₁ a b :=
+quotient.exact
+
+lemma sound' {a b : α} : @setoid.r _ s₁ a b → @quotient.mk' α s₁ a = quotient.mk' b :=
+quotient.sound
+
+@[simp] protected lemma eq' {a b : α} : @quotient.mk' α s₁ a = quotient.mk' b ↔ @setoid.r _ s₁ a b :=
+quotient.eq
+
+noncomputable def out' (a : quotient s₁) : α := quotient.out a
+
+@[simp] theorem out_eq' (q : quotient s₁) : quotient.mk' q.out' = q := q.out_eq
+
+theorem mk_out' (a : α) : @setoid.r α s₁ (quotient.mk' a).out a :=
+quotient.exact (quotient.out_eq _) 
+
+end quotient

--- a/docs/wip.md
+++ b/docs/wip.md
@@ -21,3 +21,6 @@ always welcome.
 * [Kevin Buzzard](https://github.com/kbuzzard) is working on [sheaf
   theory](https://github.com/kbuzzard/xena/blob/master/xenalib/scheme.lean)
   with a view toward algebraic geometry.
+
+* [Sean Leather](https://github.com/spl) is working on a
+  [finite map](https://github.com/spl/lean-finmap) for mathlib.

--- a/group_theory/coset.lean
+++ b/group_theory/coset.lean
@@ -5,64 +5,6 @@ Authors: Mitchell Rowett, Scott Morrison
 -/
 import group_theory.subgroup data.equiv.basic data.quot
 open set function
-
-section quotients
-variables {α : Sort*} {β : Type*} {γ : Type*} {φ : Type*} 
-  {s₁ : setoid α} {s₂ : setoid β} {s₃ : setoid γ}
-
-def quotient.mk' (a : α) : quotient s₁ := quot.mk s₁.1 a
-
-@[elab_as_eliminator, reducible]
-def quotient.lift_on' (q : quotient s₁) (f : α → φ) 
-  (h : ∀ a b, @setoid.r α s₁ a b → f a = f b) : φ := quotient.lift_on q f h
-
-@[elab_as_eliminator, reducible]
-def quotient.lift_on₂' (q₁ : quotient s₁) (q₂ : quotient s₂) (f : α → β → γ)
-  (h : ∀ a₁ a₂ b₁ b₂, @setoid.r α s₁ a₁ b₁ → @setoid.r β s₂ a₂ b₂ → f a₁ a₂ = f b₁ b₂) : γ :=
-quotient.lift_on₂ q₁ q₂ f h
-
-@[elab_as_eliminator]
-lemma quot.induction_on₃' {r₁ : α → α → Prop} {r₂ : β → β → Prop} 
-  {r₃ : γ → γ → Prop} {p : quot r₁ → quot r₂ → quot r₃ → Prop} (q₁ : quot r₁) 
-  (q₂ : quot r₂) (q₃ : quot r₃) (h : ∀ a₁ a₂ a₃, 
-    p (quot.mk r₁ a₁) (quot.mk r₂ a₂) (quot.mk r₃ a₃)) : p q₁ q₂ q₃ :=
-quot.induction_on q₁ $ λ a₁, quot.induction_on q₂ $ λ a₂, quot.induction_on
-q₃ $ λ a₃, h a₁ a₂ a₃
-
-@[elab_as_eliminator]
-lemma quotient.induction_on' {p : quotient s₁ → Prop} (q : quotient s₁)
-  (h : ∀ a, p (quot.mk s₁.1 a)) : p q := quotient.induction_on q h
-
-@[elab_as_eliminator]
-lemma quotient.induction_on₂' {p : quotient s₁ → quotient s₂ → Prop} (q₁ : quotient s₁)
-  (q₂ : quotient s₂) (h : ∀ a₁ a₂, p (quot.mk s₁.1 a₁) (@quotient.mk β s₂ a₂)) : p q₁ q₂ :=
-quotient.induction_on₂ q₁ q₂ h
-
-@[elab_as_eliminator]
-lemma quotient.induction_on₃' {p : quotient s₁ → quotient s₂ → quotient s₃ → Prop} 
-  (q₁ : quotient s₁) (q₂ : quotient s₂) (q₃ : quotient s₃) 
-  (h : ∀ a₁ a₂ a₃, p (quot.mk s₁.1 a₁) (quot.mk s₂.1 a₂) (quot.mk s₃.1 a₃)) : p q₁ q₂ q₃ :=
-quotient.induction_on₃ q₁ q₂ q₃ h
-
-lemma quotient.exact' {a b : α} : 
-  (quotient.mk' a : quotient s₁) = quotient.mk' b → @setoid.r _ s₁ a b :=
-quotient.exact
-
-lemma quotient.sound' {a b : α} : @setoid.r _ s₁ a b → @quotient.mk' α s₁ a = quotient.mk' b :=
-quotient.sound
-
-@[simp] lemma quotient.eq' {a b : α} : @quotient.mk' α s₁ a = quotient.mk' b ↔ @setoid.r _ s₁ a b :=
-quotient.eq
-
-noncomputable def quotient.out' (a : quotient s₁) : α := quotient.out a
-
-@[simp] theorem quotient.out_eq' (q : quotient s₁) : quotient.mk' q.out' = q := q.out_eq
-
-theorem quotient.mk_out' (a : α) : @setoid.r α s₁ (quotient.mk' a).out a :=
-quotient.exact (quotient.out_eq _) 
-
-end quotients
-
 variable {α : Type*}
 
 def left_coset [has_mul α] (a : α) (s : set α) : set α := (λ x, a * x) '' s
@@ -218,11 +160,11 @@ noncomputable def group_equiv_left_cosets_times_subgroup (hs : is_subgroup s) :
   α ≃ (left_cosets s × s) :=
 calc α ≃ Σ L : left_cosets s, {x : α // (x : left_cosets s)= L} :
   equiv.equiv_fib left_cosets.mk
-    ... ≃ Σ L : left_cosets s, left_coset (quotient.out L) s :
+    ... ≃ Σ L : left_cosets s, left_coset (quotient.out' L) s :
   equiv.sigma_congr_right (λ L, 
     begin rw ← left_cosets.eq_class_eq_left_coset, 
-      show {x // quotient.mk _ = _} ≃ {x : α // quotient.mk _ = quotient.mk _},
-      simp
+      show {x // quotient.mk' x = L} ≃ {x : α // quotient.mk' x = quotient.mk' _},
+      simp [-quotient.eq']
     end)
     ... ≃ Σ L : left_cosets s, s :
   equiv.sigma_congr_right (λ L, left_coset_equiv_subgroup _)
@@ -233,7 +175,7 @@ end is_subgroup
 
 namespace left_cosets
 
-instance [group α](s : set α) [normal_subgroup s] : group (left_cosets s) :=
+instance [group α] (s : set α) [normal_subgroup s] : group (left_cosets s) :=
 { one := (1 : α),
   mul := λ a b, quotient.lift_on₂' a b
     (λ a b, ((a * b : α) : left_cosets s))

--- a/group_theory/coset.lean
+++ b/group_theory/coset.lean
@@ -140,7 +140,7 @@ instance [group α] (s : set α) [is_subgroup s] : inhabited (left_cosets s) :=
 quotient.eq'
 
 lemma eq_class_eq_left_coset [group α] (s : set α) [is_subgroup s] (g : α) : 
-{x : α | (x : left_cosets s) = g} = left_coset g s :=
+  {x : α | (x : left_cosets s) = g} = left_coset g s :=
 set.ext $ λ z, by simp [eq_comm, mem_left_coset_iff]; refl
 
 end left_cosets

--- a/group_theory/coset.lean
+++ b/group_theory/coset.lean
@@ -139,7 +139,7 @@ instance [group α] (s : set α) [is_subgroup s] : inhabited (left_cosets s) :=
 @[simp] protected lemma eq {a b : α} : (a : left_cosets s) = b ↔ a⁻¹ * b ∈ s :=
 quotient.eq'
 
-lemma eq_class_eq_left_coset [group α] (s : set α) [is_subgroup s] (g : α) : 
+lemma eq_class_eq_left_coset [group α] (s : set α) [is_subgroup s] (g : α) :
   {x : α | (x : left_cosets s) = g} = left_coset g s :=
 set.ext $ λ z, by simp [eq_comm, mem_left_coset_iff]; refl
 
@@ -161,8 +161,8 @@ noncomputable def group_equiv_left_cosets_times_subgroup (hs : is_subgroup s) :
 calc α ≃ Σ L : left_cosets s, {x : α // (x : left_cosets s)= L} :
   equiv.equiv_fib left_cosets.mk
     ... ≃ Σ L : left_cosets s, left_coset (quotient.out' L) s :
-  equiv.sigma_congr_right (λ L, 
-    begin rw ← left_cosets.eq_class_eq_left_coset, 
+  equiv.sigma_congr_right (λ L,
+    begin rw ← left_cosets.eq_class_eq_left_coset,
       show {x // quotient.mk' x = L} ≃ {x : α // quotient.mk' x = quotient.mk' _},
       simp [-quotient.eq']
     end)
@@ -175,40 +175,65 @@ end is_subgroup
 
 namespace left_cosets
 
+section
+open tactic
+meta def to_lam : expr → expr
+| (expr.pi v bi d b) := expr.lam v bi d b
+| _ := default _
+
+meta def apply_quotient_induction_on_n : tactic unit :=
+do p' ← tactic.target,
+   vs ← tactic.intros,
+   p  ← tactic.target,
+   e ← match vs with
+       | [x]     :=
+         do e ← tactic.to_expr ``(@quotient.induction_on' _ _ %%(to_lam p') %%x _ : %%p) >>= instantiate_mvars,
+            all_goals (try apply_instance),
+            return e
+       | [x,y]   := tactic.to_expr ``(quotient.induction_on₂' %%x %%y _ : %%p)
+       | [x,y,z] := tactic.to_expr ``(quotient.induction_on₃' %%x %%y %%z _ : %%p)
+       | _ := tactic.fail format!"unsupported arity: {vs.length}"
+       end,
+   () <$ tactic.exact e
+
+end
+
+run_cmd add_interactive [`apply_quotient_induction_on_n]
+
 instance [group α] (s : set α) [normal_subgroup s] : group (left_cosets s) :=
-{ one := (1 : α),
-  mul := λ a b, quotient.lift_on₂' a b
-    (λ a b, ((a * b : α) : left_cosets s))
-    (λ a₁ a₂ b₁ b₂ hab₁ hab₂,
-      quot.sound
-      ((is_subgroup.mul_mem_cancel_left s (is_subgroup.inv_mem hab₂)).1
-        (by rw [mul_inv_rev, mul_inv_rev, ← mul_assoc (a₂⁻¹ * a₁⁻¹),
-          mul_assoc _ b₂, ← mul_assoc b₂, mul_inv_self, one_mul, mul_assoc (a₂⁻¹)];
-          exact normal_subgroup.normal _ hab₁ _))),
-  mul_assoc := λ a b c, quotient.induction_on₃' a b c 
-    (λ a b c, congr_arg mk (mul_assoc a b c)), 
-  one_mul := λ a, quotient.induction_on' a
-    (λ a, congr_arg mk (one_mul a)),
-  mul_one := λ a, quotient.induction_on' a
-    (λ a, congr_arg mk (mul_one a)),
-  inv := λ a, quotient.lift_on' a (λ a, ((a⁻¹ : α) : left_cosets s))
-    (λ a b hab, quotient.sound' begin
-      show a⁻¹⁻¹ * b⁻¹ ∈ s,
-      rw ← mul_inv_rev,
-      exact is_subgroup.inv_mem (is_subgroup.mem_norm_comm hab)
-    end),
-  mul_left_inv := λ a, quotient.induction_on' a
-    (λ a, congr_arg mk (mul_left_inv a)) }
+begin
+  refine_struct { one := ↑(1 : α), .. },
+  field mul
+  { intros x y, refine quotient.lift_on₂' x y _ _,
+    { intros x y, exact (x * y : α) },
+    { introv hab₁ hab₂, apply quot.sound,
+      apply (is_subgroup.mul_mem_cancel_left s (is_subgroup.inv_mem hab₂)).1,
+      rw [mul_inv_rev, mul_inv_rev, ← mul_assoc (a₂⁻¹ * a₁⁻¹),
+      mul_assoc _ b₂, ← mul_assoc b₂, mul_inv_self, one_mul, mul_assoc (a₂⁻¹)];
+      exact normal_subgroup.normal _ hab₁ _, } },
+  field inv
+  { intro,
+    apply quotient.lift_on' a (λ a, ((a⁻¹ : α) : left_cosets s))
+           (λ a b hab, quotient.sound' begin
+             show a⁻¹⁻¹ * b⁻¹ ∈ s,
+             rw ← mul_inv_rev,
+             exact is_subgroup.inv_mem (is_subgroup.mem_norm_comm hab)
+           end)  },
+  all_goals
+  { have_field,
+    apply_quotient_induction_on_n,
+    intros, apply congr_arg mk _, apply field },
+end
 
 instance [group α] (s : set α) [normal_subgroup s] :
   is_group_hom (mk : α → left_cosets s) := ⟨λ _ _, rfl⟩
 
 instance [comm_group α] (s : set α) [normal_subgroup s] : comm_group (left_cosets s) :=
-{ mul_comm := λ a b, quotient.induction_on₂' a b 
+{ mul_comm := λ a b, quotient.induction_on₂' a b
     (λ a b, congr_arg mk (mul_comm a b)),
   ..left_cosets.group s }
 
-@[simp] lemma coe_one [group α] (s : set α) [normal_subgroup s] : 
+@[simp] lemma coe_one [group α] (s : set α) [normal_subgroup s] :
   ((1 : α) : left_cosets s) = 1 := rfl
 
 @[simp] lemma coe_mul [group α] (s : set α) [normal_subgroup s] (a b : α) :

--- a/group_theory/subgroup.lean
+++ b/group_theory/subgroup.lean
@@ -124,6 +124,10 @@ by simp at h; exact h
 lemma mem_norm_comm_iff {a b : α} {s : set α} [normal_subgroup s] : a * b ∈ s ↔ b * a ∈ s :=
 iff.intro mem_norm_comm mem_norm_comm
 
+lemma normal' {a b : α} {s : set α} [normal_subgroup s] :
+  ∀ n ∈ s, ∀ g : α, g⁻¹ * n * g ∈ s :=
+by intros; rw [mem_norm_comm_iff, ← mul_assoc]; simp *
+
 /-- The trivial subgroup -/
 def trivial (α : Type*) [group α] : set α := {1}
 

--- a/meta/expr.lean
+++ b/meta/expr.lean
@@ -42,4 +42,11 @@ meta def pis : list expr → expr → tactic expr
   pure $ pi pp info t (abstract_local f' uniq)
 | _ f := pure f
 
+meta def lambdas : list expr → expr → tactic expr
+| (e@(local_const uniq pp info _) :: es) f := do
+  t ← infer_type e,
+  f' ← lambdas es f,
+  pure $ lam pp info t (abstract_local f' uniq)
+| _ f := pure f
+
 end tactic

--- a/order/basic.lean
+++ b/order/basic.lean
@@ -74,14 +74,14 @@ def preorder.dual (o : preorder α) : preorder α :=
   le_refl  := le_refl,
   le_trans := assume a b c h₁ h₂, le_trans h₂ h₁ }
 
-instance preorder_fun {ι : Type u} {α : ι → Type v} [∀i, preorder (α i)] : preorder (Πi, α i) :=
+instance pi.preorder {ι : Type u} {α : ι → Type v} [∀i, preorder (α i)] : preorder (Πi, α i) :=
 { le       := λx y, ∀i, x i ≤ y i,
   le_refl  := assume a i, le_refl (a i),
   le_trans := assume a b c h₁ h₂ i, le_trans (h₁ i) (h₂ i) }
 
-instance partial_order_fun {ι : Type u} {α : ι → Type v} [∀i, partial_order (α i)] : partial_order (Πi, α i) :=
+instance pi.partial_order {ι : Type u} {α : ι → Type v} [∀i, partial_order (α i)] : partial_order (Πi, α i) :=
 { le_antisymm := λf g h1 h2, funext (λb, le_antisymm (h1 b) (h2 b)),
-  ..preorder_fun }
+  ..pi.preorder }
 
 /-- Order dual of a partial order -/
 def partial_order.dual (wo : partial_order α) : partial_order α :=

--- a/order/bounded_lattice.lean
+++ b/order/bounded_lattice.lean
@@ -260,7 +260,7 @@ end logic
  * build up the lattice hierarchy for `fun`-functor piecewise. semilattic_*, bounded_lattice, lattice ...
  * can this be generalized to the dependent function space?
 -/
-instance bounded_lattice_fun {α : Type u} {β : Type v} [bounded_lattice β] :
+instance pi.bounded_lattice {α : Type u} {β : Type v} [bounded_lattice β] :
   bounded_lattice (α → β) :=
 { sup          := λf g a, f a ⊔ g a,
   le_sup_left  := assume f g a, le_sup_left,
@@ -277,7 +277,7 @@ instance bounded_lattice_fun {α : Type u} {β : Type v} [bounded_lattice β] :
 
   bot          := λa, ⊥,
   bot_le       := assume f a, bot_le,
-  ..partial_order_fun }
+  ..pi.partial_order }
 
 end lattice
 

--- a/order/complete_lattice.lean
+++ b/order/complete_lattice.lean
@@ -620,7 +620,7 @@ instance complete_lattice_Prop : complete_lattice Prop :=
   le_Inf := assume s a h p b hb, h b hb p,
   ..lattice.bounded_lattice_Prop }
 
-instance complete_lattice_fun {α : Type u} {β : Type v} [complete_lattice β] :
+instance pi.complete_lattice {α : Type u} {β : Type v} [complete_lattice β] :
   complete_lattice (α → β) :=
 { Sup    := λs a, Sup (set.image (λf : α → β, f a) s),
   le_Sup := assume s f h a, le_Sup ⟨f, h, rfl⟩,
@@ -628,7 +628,7 @@ instance complete_lattice_fun {α : Type u} {β : Type v} [complete_lattice β] 
   Inf    := λs a, Inf (set.image (λf : α → β, f a) s),
   Inf_le := assume s f h a, Inf_le ⟨f, h, rfl⟩,
   le_Inf := assume s f h a, le_Inf $ assume b ⟨f', h', b_eq⟩, b_eq ▸ h _ h' a,
-  ..lattice.bounded_lattice_fun }
+  ..lattice.pi.bounded_lattice }
 
 section complete_lattice
 variables [preorder α] [complete_lattice β]

--- a/ring_theory/ideals.lean
+++ b/ring_theory/ideals.lean
@@ -217,7 +217,7 @@ exact have span (set.insert a S) = S :=
     (subset.trans (subset_insert _ _) subset_span)) (is_proper_ideal.ne_univ _),
   haS (this ▸ subset_span (mem_insert _ _))
 
-/- quotient by maximal ideal is a field. def rather than instance, since users will have
+/-- quotient by maximal ideal is a field. def rather than instance, since users will have
 computable inverses in some applications -/
 protected noncomputable def field (S : set α) [is_maximal_ideal S] : field (quotient S) :=
 { inv := λ a, if ha : a = 0 then 0 else classical.some (exists_inv ha),

--- a/ring_theory/ideals.lean
+++ b/ring_theory/ideals.lean
@@ -27,9 +27,15 @@ lemma mul_left {S : set α} [is_ideal S] : b ∈ S → a * b ∈ S := @is_submod
 
 lemma mul_right {S : set α} [is_ideal S] : a ∈ S → a * b ∈ S := mul_comm b a ▸ mul_left
 
-end is_ideal
+def trivial (α : Type*) [comm_ring α] : set α := {0}
 
-instance (S : set α) : is_ideal (span S) := {}
+instance : is_ideal (trivial α) := by refine {..}; simp [trivial] {contextual := tt}
+
+instance univ : is_ideal (@univ α) := {}
+
+instance span (S : set α) : is_ideal (span S) := {}
+
+end is_ideal
 
 class is_proper_ideal {α : Type u} [comm_ring α] (S : set α) extends is_ideal S : Prop :=
 (ne_univ : S ≠ set.univ)

--- a/ring_theory/ideals.lean
+++ b/ring_theory/ideals.lean
@@ -99,60 +99,83 @@ have hi : is_submodule (nonunits α), from
     id
     (λ htu, false.elim $ ((set.ext_iff _ _).1 htu 1).2 trivial ⟨1, mul_one 1⟩) }
 
-namespace is_ideal
+namespace quotient_ring
+open is_ideal
 
 def quotient_rel (S : set α) [is_ideal S] := is_submodule.quotient_rel S
 
-local attribute [instance] quotient_rel
-
 def quotient (S : set α) [is_ideal S] := quotient (quotient_rel S)
 
+def mk {S : set α} [is_ideal S] (a : α) : quotient S :=
+quotient.mk' a
+
+instance {S : set α} [is_ideal S] : has_coe α (quotient S) := ⟨mk⟩
+
 instance (S : set α) [is_ideal S] : comm_ring (quotient S) :=
-{ mul := λ a b, quotient.lift_on₂ a b (λ a b, ⟦a * b⟧) 
+{ mul := λ a b, quotient.lift_on₂' a b (λ a b, ((a * b : α) : quotient S))
   (λ a₁ a₂ b₁ b₂ (h₁ : a₁ - b₁ ∈ S) (h₂ : a₂ - b₂ ∈ S), 
-    quotient.sound
+    quotient.sound'
     (show a₁ * a₂ - b₁ * b₂ ∈ S, from
     have h : a₂ * (a₁ - b₁) + (a₂ - b₂) * b₁ =
       a₁ * a₂ - b₁ * b₂, by ring,
     h ▸ is_ideal.add (mul_left h₁) (mul_right h₂))),
-  mul_assoc := λ a b c, quotient.induction_on₃ a b c $ 
-    λ a b c, show ⟦_⟧ = ⟦_⟧, by rw mul_assoc,
-  mul_comm := λ a b, quotient.induction_on₂ a b $
-    λ a b, show ⟦_⟧ = ⟦_⟧, by rw mul_comm,
-  one := ⟦1⟧,
-  one_mul := λ a, quotient.induction_on a $
-    λ a, show ⟦_⟧ = ⟦_⟧, by rw one_mul,
-  mul_one := λ a, quotient.induction_on a $
-    λ a, show ⟦_⟧ = ⟦_⟧, by rw mul_one,
-  left_distrib := λ a b c, quotient.induction_on₃ a b c $ 
-    λ a b c, show ⟦_⟧ = ⟦_⟧, by rw mul_add,
-  right_distrib := λ a b c, quotient.induction_on₃ a b c $ 
-    λ a b c, show ⟦_⟧ = ⟦_⟧, by rw add_mul,
+  mul_assoc := λ a b c, quotient.induction_on₃' a b c $ 
+    λ a b c, congr_arg mk (mul_assoc a b c),
+  mul_comm := λ a b, quotient.induction_on₂' a b $
+    λ a b, congr_arg mk (mul_comm a b),
+  one := (1 : α),
+  one_mul := λ a, quotient.induction_on' a $
+    λ a, congr_arg mk (one_mul a),
+  mul_one := λ a, quotient.induction_on' a $
+    λ a, congr_arg mk (mul_one a),
+  left_distrib := λ a b c, quotient.induction_on₃' a b c $ 
+    λ a b c, congr_arg mk (left_distrib a b c),
+  right_distrib := λ a b c, quotient.induction_on₃' a b c $ 
+    λ a b c, congr_arg mk (right_distrib a b c),
   ..is_submodule.quotient.add_comm_group S }
 
-lemma quotient_eq_zero_iff_mem {S : set α} [is_ideal S] : ⟦a⟧ = (0 : quotient S) ↔ a ∈ S :=
-by conv {to_rhs, rw ← sub_zero a }; exact quotient.eq
+instance is_ring_hom_mk (S : set α) [is_ideal S] : 
+  @is_ring_hom _ (quotient S) _ _ mk :=
+by refine {..}; intros; refl
+
+@[simp] lemma coe_zero (S : set α) [is_ideal S] : ((0 : α) : quotient S) = 0 := rfl
+@[simp] lemma coe_one (S : set α) [is_ideal S] : ((1 : α) : quotient S) = 1 := rfl
+@[simp] lemma coe_add (S : set α) [is_ideal S] (a b : α) : ((a + b : α) : quotient S) = a + b := rfl
+@[simp] lemma coe_mul (S : set α) [is_ideal S] (a b : α) : ((a * b : α) : quotient S) = a * b := rfl
+@[simp] lemma coe_neg (S : set α) [is_ideal S] (a : α) : ((-a : α) : quotient S) = -a := rfl
+@[simp] lemma coe_sub (S : set α) [is_ideal S] (a b : α) : ((a - b : α) : quotient S) = a - b := rfl
+@[simp] lemma coe_bit0 (S : set α) [is_ideal S] (a : α) : ((bit0 a : α) : quotient S) = bit0 a := rfl
+@[simp] lemma coe_bit1 (S : set α) [is_ideal S] (a : α) : ((bit1 a : α) : quotient S) = bit1 a := rfl
+@[simp] lemma coe_pow (S : set α) [is_ideal S] (a : α) (n : ℕ) : ((a ^ n : α) : quotient S) = a ^ n :=
+by induction n; simp [*, pow_succ]
+
+lemma eq_zero_iff_mem {S : set α} [is_ideal S] : 
+  (a : quotient S) = 0 ↔ a ∈ S :=
+by conv {to_rhs, rw ← sub_zero a }; exact quotient.eq'
+
+instance (S : set α) [is_proper_ideal S] : nonzero_comm_ring (quotient S) :=
+{ zero_ne_one := ne.symm $ mt eq_zero_iff_mem.1 
+    (is_proper_ideal_iff_one_not_mem.1 (by apply_instance)),
+  ..quotient_ring.comm_ring S }
 
 instance (S : set α) [is_prime_ideal S] : integral_domain (quotient S) :=
-{ zero_ne_one := ne.symm $ mt quotient_eq_zero_iff_mem.1 
-    (is_proper_ideal_iff_one_not_mem.1 (by apply_instance)),
-  eq_zero_or_eq_zero_of_mul_eq_zero := λ a b,
-    quotient.induction_on₂ a b $ λ a b hab,
+{ eq_zero_or_eq_zero_of_mul_eq_zero := λ a b,
+    quotient.induction_on₂' a b $ λ a b hab,
       (is_prime_ideal.mem_or_mem_of_mul_mem 
-        (quotient_eq_zero_iff_mem.1 hab)).elim
-      (or.inl ∘ quotient_eq_zero_iff_mem.2)
-      (or.inr ∘ quotient_eq_zero_iff_mem.2),
-  ..is_ideal.comm_ring S }
+        (eq_zero_iff_mem.1 hab)).elim
+      (or.inl ∘ eq_zero_iff_mem.2)
+      (or.inr ∘ eq_zero_iff_mem.2),
+  ..quotient_ring.nonzero_comm_ring S }
 
 lemma exists_inv {S : set α} [is_maximal_ideal S] {a : quotient S} : a ≠ 0 →
   ∃ b : quotient S, a * b = 1 :=
-quotient.induction_on a $ λ a ha,
+quotient.induction_on' a $ λ a ha,
 classical.by_contradiction $ λ h,
-have haS : a ∉ S := mt quotient_eq_zero_iff_mem.2 ha,
+have haS : a ∉ S := mt eq_zero_iff_mem.2 ha,
 by haveI hS : is_proper_ideal (span (set.insert a S)) :=
   is_proper_ideal_iff_one_not_mem.2
   (mt mem_span_insert.1 $ λ ⟨b, hb⟩,
-  h ⟨-⟦b⟧, quotient.sound (show a * -b - 1 ∈ S,
+  h ⟨-b, quotient.sound' (show a * -b - 1 ∈ S,
     from neg_iff.2 (begin
       rw [neg_sub, mul_neg_eq_neg_mul_symm, sub_eq_add_neg, neg_neg, mul_comm],
       rw span_eq_of_is_submodule (show is_submodule S, by apply_instance) at hb,
@@ -173,10 +196,6 @@ protected noncomputable def field (S : set α) [is_maximal_ideal S] : field (quo
   inv_mul_cancel := λ a (ha : a ≠ 0), show dite _ _ _ * a = _, 
     by rw [mul_comm, dif_neg ha];
     exact classical.some_spec (exists_inv ha),
-  ..is_ideal.integral_domain S }
+  ..quotient_ring.integral_domain S }
 
-instance is_ring_hom_quotient_mk (S : set α) [is_ideal S] : 
-  @is_ring_hom _ (quotient S) _ _ quotient.mk :=
-by refine {..}; intros; refl
-
-end is_ideal
+end quotient_ring

--- a/ring_theory/ideals.lean
+++ b/ring_theory/ideals.lean
@@ -136,7 +136,7 @@ instance (S : set α) [is_ideal S] : comm_ring (quotient S) :=
 
 instance is_ring_hom_mk (S : set α) [is_ideal S] : 
   @is_ring_hom _ (quotient S) _ _ mk :=
-by refine {..}; intros; refl
+⟨λ _ _, rfl, λ _ _, rfl, rfl⟩ 
 
 @[simp] lemma coe_zero (S : set α) [is_ideal S] : ((0 : α) : quotient S) = 0 := rfl
 @[simp] lemma coe_one (S : set α) [is_ideal S] : ((1 : α) : quotient S) = 1 := rfl
@@ -163,8 +163,8 @@ instance (S : set α) [is_prime_ideal S] : integral_domain (quotient S) :=
     quotient.induction_on₂' a b $ λ a b hab,
       (is_prime_ideal.mem_or_mem_of_mul_mem 
         (eq_zero_iff_mem.1 hab)).elim
-      (or.inl ∘ eq_zero_iff_mem.2)
-      (or.inr ∘ eq_zero_iff_mem.2),
+          (or.inl ∘ eq_zero_iff_mem.2)
+          (or.inr ∘ eq_zero_iff_mem.2),
   ..quotient_ring.nonzero_comm_ring S }
 
 lemma exists_inv {S : set α} [is_maximal_ideal S] {a : quotient S} : a ≠ 0 →

--- a/tactic/interactive.lean
+++ b/tactic/interactive.lean
@@ -443,6 +443,13 @@ get_current_field
 >>= note `field none
 >>  return ()
 
+meta def let_field : tactic unit :=
+propagate_tags $
+get_current_field
+>>= mk_const
+>>= pose `field none
+>>  return ()
+
 /-- `apply_field` functions as `have_field, apply field, clear field` -/
 meta def apply_field : tactic unit :=
 propagate_tags $

--- a/tactic/interactive.lean
+++ b/tactic/interactive.lean
@@ -448,6 +448,14 @@ meta def apply_field : tactic unit :=
 propagate_tags $
 get_current_field >>= applyc
 
+meta def field (n : parse ident) (tac : itactic) : tactic unit :=
+do gs ← get_goals,
+   ts ← gs.mmap get_tag,
+   ([g],gs') ← pure $ (list.zip gs ts).partition (λ x, x.snd.nth 1 = some n),
+   set_goals [g.1],
+   tac, done,
+   set_goals $ gs'.map prod.fst
+
 /--`apply_rules hs n`: apply the list of rules `hs` (given as pexpr) and `assumption` on the
 first goal and the resulting subgoals, iteratively, at most `n` times.
 `n` is 50 by default. `hs` can contain user attributes: in this case all theorems with this

--- a/tactic/norm_num.lean
+++ b/tactic/norm_num.lean
@@ -6,10 +6,9 @@ Authors: Simon Hudon, Mario Carneiro
 Evaluating arithmetic expressions including *, +, -, ^, ≤
 -/
 
-import algebra.group_power data.rat tactic.interactive
+import algebra.group_power data.rat tactic.interactive data.nat.prime
 
 universes u v w
-open tactic
 
 namespace expr
 
@@ -35,6 +34,22 @@ protected meta def of_rat (α : expr) : ℚ → tactic expr
   tactic.mk_app ``has_neg.neg [e]
 
 end expr
+
+namespace tactic
+
+meta def refl_conv (e : expr) : tactic (expr × expr) :=
+do p ← mk_eq_refl e, return (e, p)
+
+meta def trans_conv (t₁ t₂ : expr → tactic (expr × expr)) (e : expr) :
+  tactic (expr × expr) :=
+(do (e₁, p₁) ← t₁ e,
+  (do (e₂, p₂) ← t₂ e₁,
+    p ← mk_eq_trans p₁ p₂, return (e₂, p)) <|>
+  return (e₁, p₁)) <|> t₂ e
+
+end tactic
+
+open tactic
 
 namespace norm_num
 variable {α : Type u}
@@ -259,7 +274,7 @@ meta def eval_div_ext (simp : expr → tactic (expr × expr)) : expr → tactic 
     return (r, p)
   | `(int) := match e₂ with
     | `(- %%e₂') := do
-      (c, p₁) ← c.mk_app ``int.mod_neg [e₁, e₂'],
+      let p₁ := (expr.const ``int.mod_neg []).mk_app [e₁, e₂'],
       (c, e) ← c.mk_app ``has_mod.mod [e₁, e₂'],
       (e', p₂) ← simp e,
       p ← mk_eq_trans p₁ p₂,
@@ -283,11 +298,167 @@ meta def eval_div_ext (simp : expr → tactic (expr × expr)) : expr → tactic 
     end
   | _ := failed
   end
+| `(%%e₁ ∣ %%e₂) := do
+  α ← infer_type e₁,
+  c ← mk_instance_cache α,
+  n ← match α with
+  | `(nat) := return ``nat.dvd_iff_mod_eq_zero
+  | `(int) := return ``int.dvd_iff_mod_eq_zero
+  | _ := failed
+  end,
+  p₁ ← mk_app ``propext [@expr.const tt n [] e₁ e₂],
+  (e', p₂) ← simp `(%%e₂ % %%e₁ = 0),
+  p' ← mk_eq_trans p₁ p₂,
+  return (e', p')
+| _ := failed
+
+lemma not_prime_helper (a b n : ℕ)
+  (h : a * b = n) (h₁ : 1 < a) (h₂ : 1 < b) : ¬ nat.prime n :=
+by rw ← h; exact nat.not_prime_mul h₁ h₂
+
+lemma is_prime_helper (n : ℕ)
+  (h₁ : 1 < n) (h₂ : nat.min_fac n = n) : nat.prime n :=
+nat.prime_def_min_fac.2 ⟨h₁, h₂⟩
+
+lemma min_fac_bit0 (n : ℕ) : nat.min_fac (bit0 n) = 2 :=
+by simp [nat.min_fac_eq, show 2 ∣ bit0 n, by simp [bit0_eq_two_mul n]]
+
+def min_fac_helper (n k : ℕ) : Prop :=
+0 < k ∧ bit1 k ≤ nat.min_fac (bit1 n)
+
+theorem min_fac_helper.n_pos {n k : ℕ} (h : min_fac_helper n k) : 0 < n :=
+nat.pos_iff_ne_zero.2 $ λ e,
+by rw e at h; exact not_le_of_lt (nat.bit1_lt h.1) h.2
+
+lemma min_fac_ne_bit0 {n k : ℕ} : nat.min_fac (bit1 n) ≠ bit0 k :=
+by rw bit0_eq_two_mul; exact λ e, absurd
+  ((nat.dvd_add_iff_right (by simp [bit0_eq_two_mul n])).2
+    (dvd_trans ⟨_, e⟩ (nat.min_fac_dvd _)))
+  dec_trivial
+
+lemma min_fac_helper_0 (n : ℕ) (h : 0 < n) : min_fac_helper n 1 :=
+begin
+  refine ⟨zero_lt_one, lt_of_le_of_ne _ min_fac_ne_bit0.symm⟩,
+  refine @lt_of_le_of_ne ℕ _ _ _ (nat.min_fac_pos _) _,
+  intro e,
+  have := nat.min_fac_prime _,
+  { rw ← e at this, exact nat.not_prime_one this },
+  { exact ne_of_gt (nat.bit1_lt h) }
+end
+
+lemma min_fac_helper_1 {n k k' : ℕ} (e : k + 1 = k')
+  (np : nat.min_fac (bit1 n) ≠ bit1 k)
+  (h : min_fac_helper n k) : min_fac_helper n k' :=
+begin
+  rw ← e,
+  refine ⟨nat.succ_pos _,
+    (lt_of_le_of_ne (lt_of_le_of_ne _ _ : k+1+k < _)
+      min_fac_ne_bit0.symm : bit0 (k+1) < _)⟩,
+  { rw add_right_comm, exact h.2 },
+  { rw add_right_comm, exact np.symm }
+end
+
+lemma min_fac_helper_2 (n k k' : ℕ) (e : k + 1 = k')
+  (np : ¬ nat.prime (bit1 k)) (h : min_fac_helper n k) : min_fac_helper n k' :=
+begin
+  refine min_fac_helper_1 e _ h,
+  intro e₁, rw ← e₁ at np,
+  exact np (nat.min_fac_prime $ ne_of_gt $ nat.bit1_lt h.n_pos)
+end
+
+lemma min_fac_helper_3 (n k k' : ℕ) (e : k + 1 = k')
+  (nd : bit1 k ∣ bit1 n = false)
+  (h : min_fac_helper n k) : min_fac_helper n k' :=
+begin
+  refine min_fac_helper_1 e _ h,
+  intro e₁, rw [eq_false, ← e₁] at nd,
+  exact nd (nat.min_fac_dvd _)
+end
+
+lemma min_fac_helper_4 (n k : ℕ) (hd : bit1 k ∣ bit1 n = true)
+  (h : min_fac_helper n k) : nat.min_fac (bit1 n) = bit1 k :=
+by rw eq_true at hd; exact
+le_antisymm (nat.min_fac_le_of_dvd (nat.bit1_lt h.1) hd) h.2
+
+lemma min_fac_helper_5 (n k k' : ℕ) (e : bit1 k * bit1 k = k')
+  (hd : bit1 n < k') (h : min_fac_helper n k) : nat.min_fac (bit1 n) = bit1 n :=
+begin
+  refine (nat.prime_def_min_fac.1 (nat.prime_def_le_sqrt.2
+    ⟨nat.bit1_lt h.n_pos, _⟩)).2,
+  rw ← e at hd,
+  intros m m2 hm md,
+  have := le_trans h.2 (le_trans (nat.min_fac_le_of_dvd m2 md) hm),
+  rw nat.le_sqrt at this,
+  exact not_le_of_lt hd this
+end
+
+meta def prove_non_prime (simp : expr → tactic (expr × expr)) (e : expr) (n d₁ : ℕ) : tactic expr :=
+do let e₁ := reflect d₁,
+  c ← mk_instance_cache `(nat),
+  (c, p₁) ← prove_lt simp c `(1) e₁,
+  let d₂ := n / d₁, let e₂ := reflect d₂,
+  (e', p) ← mk_app ``has_mul.mul [e₁, e₂] >>= norm_num,
+  guard (e' =ₐ e),
+  (c, p₂) ← prove_lt simp c `(1) e₂,
+  return $ (expr.const ``not_prime_helper []).mk_app [e₁, e₂, e, p, p₁, p₂]
+
+meta def prove_min_fac (simp : expr → tactic (expr × expr))
+  (e₁ : expr) (n1 : ℕ) : expr → expr → tactic (expr × expr)
+| e₂ p := do
+  k ← e₂.to_nat,
+  let k1 := bit1 k,
+  e₁1 ← mk_app ``bit1 [e₁],
+  e₂1 ← mk_app ``bit1 [e₂],
+  if n1 < k1*k1 then do
+    c ← mk_instance_cache `(nat),
+    (c, e') ← c.mk_app ``has_mul.mul [e₂1, e₂1],
+    (e', p₁) ← norm_num e',
+    (c, p₂) ← prove_lt simp c e₁1 e',
+    p' ← mk_app ``min_fac_helper_5 [e₁, e₂, e', p₁, p₂, p],
+    return (e₁1, p')
+  else let d := k1.min_fac in
+  if to_bool (d < k1) then do
+    (e', p₁) ← norm_num `(%%e₂ + 1),
+    p₂ ← prove_non_prime simp e₂1 k1 d,
+    mk_app ``min_fac_helper_2 [e₁, e₂, e', p₁, p₂, p] >>= prove_min_fac e'
+  else do
+    (_, p₂) ← simp `((%%e₂1 : ℕ) ∣ %%e₁1),
+    if k1 ∣ n1 then do
+      p' ← mk_app ``min_fac_helper_4 [e₁, e₂, p₂, p],
+      return (e₂1, p')
+    else do
+      (e', p₁) ← norm_num `(%%e₂ + 1),
+      mk_app ``min_fac_helper_3 [e₁, e₂, e', p₁, p₂, p] >>= prove_min_fac e'
+
+meta def eval_prime (simp : expr → tactic (expr × expr)) : expr → tactic (expr × expr)
+| `(nat.prime %%e) := do
+  n ← e.to_nat,
+  match n with
+  | 0 := false_intro `(nat.not_prime_zero)
+  | 1 := false_intro `(nat.not_prime_one)
+  | _ := let d₁ := n.min_fac in
+    if d₁ < n then prove_non_prime simp e n d₁ >>= false_intro
+    else do
+      let e₁ := reflect d₁,
+      c ← mk_instance_cache `(nat),
+      (c, p₁) ← prove_lt simp c `(1) e₁,
+      (e₁, p) ← simp `(nat.min_fac %%e),
+      true_intro $ (expr.const ``is_prime_helper []).mk_app [e, p₁, p]
+  end
+| `(nat.min_fac 0) := refl_conv (reflect (0:ℕ))
+| `(nat.min_fac 1) := refl_conv (reflect (1:ℕ))
+| `(nat.min_fac (bit0 %%e)) := prod.mk `(2) <$> mk_app ``min_fac_bit0 [e]
+| `(nat.min_fac (bit1 %%e)) := do
+  n ← e.to_nat,
+  c ← mk_instance_cache `(nat),
+  (c, p) ← prove_pos c e,
+  mk_app ``min_fac_helper_0 [e, p] >>= prove_min_fac simp e (bit1 n) `(1)
 | _ := failed
 
 meta def derive1 (simp : expr → tactic (expr × expr)) (e : expr) :
   tactic (expr × expr) :=
-norm_num e <|> eval_div_ext simp e <|> eval_pow simp e <|> eval_ineq simp e
+norm_num e <|> eval_div_ext simp e <|>
+eval_pow simp e <|> eval_ineq simp e <|> eval_prime simp e
 
 meta def derive : expr → tactic (expr × expr) | e :=
 do (_, e', pr) ←

--- a/tactic/rewrite.lean
+++ b/tactic/rewrite.lean
@@ -1,0 +1,232 @@
+import data.dlist
+import meta.expr
+
+namespace tactic
+open expr list
+
+meta def match_fn (fn : expr) : expr → tactic (expr × expr)
+| (app (app fn' e₀) e₁) :=
+(e₀,e₁) <$ unify fn fn'
+| _ := failed
+
+meta def fill_args : expr → tactic (expr × list expr)
+| (pi n bi d b) :=
+do v ← mk_meta_var d,
+   (r,vs) ← fill_args (b.instantiate_var v),
+   return (r,v::vs)
+| e := return (e,[])
+
+meta def mk_assoc_pattern' (fn : expr) : expr → tactic (dlist expr)
+| e :=
+(do (e₀,e₁) ← match_fn fn e,
+    (++) <$> mk_assoc_pattern' e₀ <*> mk_assoc_pattern' e₁) <|>
+pure (dlist.singleton e)
+
+meta def mk_assoc_pattern (fn e : expr) : tactic (list expr) :=
+dlist.to_list <$> mk_assoc_pattern' fn e
+
+meta def mk_assoc (fn : expr) : list expr → tactic expr
+| [] := failed
+| [x] := pure x
+| (x₀ :: x₁ :: xs) := mk_assoc (fn x₀ x₁ :: xs)
+
+meta def chain_eq_trans : list expr → tactic expr
+| [] := to_expr ``(rfl)
+| [e] := pure e
+| (e :: es) := chain_eq_trans es >>= mk_eq_trans e
+
+meta def unify_prefix : list expr → list expr → tactic unit
+| [] _ := pure ()
+| _ [] := failed
+| (x :: xs) (y :: ys) :=
+unify x y >> unify_prefix xs ys
+
+meta def match_assoc_pattern' (p : list expr) : list expr → tactic (list expr × list expr) | es :=
+([],es.drop p.length) <$ unify_prefix p es <|>
+  match es with
+  | [] := failed
+  | (x :: xs) :=
+    prod.map (cons x) id <$> match_assoc_pattern' xs
+  end
+
+meta def match_assoc_pattern (fn p e : expr) : tactic (list expr × list expr) :=
+do p' ← mk_assoc_pattern fn p,
+   e' ← mk_assoc_pattern fn e,
+   match_assoc_pattern' p' e'
+
+meta def mk_eq_proof (fn : expr) (e₀ e₁ : list expr) (p : expr) : tactic (expr × expr × expr) :=
+do (l,r) ← infer_type p >>= match_eq,
+   if e₀.empty ∧ e₁.empty then pure (l,r,p)
+   else do
+     l' ← mk_assoc fn (e₀ ++ [l] ++ e₁),
+     r' ← mk_assoc fn (e₀ ++ [r] ++ e₁),
+     t  ← infer_type l',
+     v  ← mk_local_def `x t,
+     e  ← mk_assoc fn (e₀ ++ [v] ++ e₁),
+     p  ← mk_congr_arg (e.lambdas [v]) p,
+     p' ← mk_id_eq l' r' p,
+     return (l',r',p')
+
+meta def assoc_root (fn assoc : expr) : expr → tactic (expr × expr) | e :=
+(do (e₀,e₁) ← match_fn fn e,
+    (ea,eb) ← match_fn fn e₁,
+    let e' := fn (fn e₀ ea) eb,
+    p' ← mk_eq_symm (assoc e₀ ea eb),
+    (e'',p'') ← assoc_root e',
+    prod.mk e'' <$> mk_eq_trans p' p'' ) <|>
+prod.mk e <$> mk_eq_refl e
+
+meta def assoc_refl' (fn assoc : expr) : expr → expr → tactic expr
+| l r :=
+(is_def_eq l r >> mk_eq_refl l) <|>
+(do (l',l_p)  ← assoc_root fn assoc l <|> fail "A",
+    (el₀,el₁) ← match_fn   fn l' <|> fail "B",
+    (r',r_p)  ← assoc_root fn assoc r <|> fail "C",
+    (er₀,er₁) ← match_fn   fn r' <|> fail "D",
+    p₀ ← assoc_refl' el₀ er₀,
+    p₁ ← is_def_eq el₁ er₁ >> mk_eq_refl el₁,
+    f_eq ← mk_congr_arg fn p₀ <|> fail "G",
+    p' ← mk_congr f_eq p₁ <|> fail "H",
+    r_p' ← mk_eq_symm r_p,
+    chain_eq_trans [l_p,p',r_p'] )
+
+meta def assoc_refl (fn : expr) : tactic unit :=
+do (l,r) ← target >>= match_eq,
+   assoc ← mk_mapp ``is_associative.assoc [none,fn,none]
+     <|> fail format!"{fn} is not associative",
+   assoc_refl' fn assoc l r >>= tactic.exact
+
+meta def flatten (fn assoc e : expr) : tactic (expr × expr) :=
+do ls ← mk_assoc_pattern fn e,
+   e' ← mk_assoc fn ls,
+   p  ← assoc_refl' fn assoc e e',
+   return (e',p)
+
+meta def assoc_rewrite_intl (assoc h e : expr) : tactic (expr × expr) :=
+do t ← infer_type h,
+   (lhs,rhs) ← match_eq t,
+   let fn  := lhs.app_fn.app_fn,
+   (l,r) ← match_assoc_pattern fn lhs e,
+   (lhs',rhs',h') ← mk_eq_proof fn l r h,
+   e_p ← assoc_refl' fn assoc e lhs',
+   (rhs'',rhs_p) ← flatten fn assoc rhs',
+   final_p ← chain_eq_trans [e_p,h',rhs_p],
+   return (rhs'', final_p)
+
+example : ∀ x y z a b c : ℕ, true :=
+begin
+ intros,
+ have : x + (y + z) = 3 + y, admit,
+ have : a + (b + x) + y + (z + b + c) ≤ 0,
+ (do this ← get_local `this,
+     tgt ← to_expr ```(a + (b + x) + y + (z + b + c)),
+     assoc ← mk_mapp ``add_monoid.add_assoc [`(ℕ),none],
+     (l,p) ← assoc_rewrite_intl assoc this tgt,
+     note `h none p  ),
+ erw h,
+ guard_target a + b + 3 + y + b + c ≤ 0,
+ admit,
+ trivial
+end
+
+meta def expr.mfoldl {α : Type} {m} [monad m] (f : α → expr → m α) : α → expr → m α
+| x e := prod.snd <$> (state_t.run (expr.traverse (λ e', get >>= (monad_lift ∘ flip f e') >>= put >> pure e') e) x : m _)
+
+-- TODO(Simon): visit expressions built of `fn` nested inside other such expressions:
+-- e.g.: x + f (a + b + c) + y should generate two rewrite candidates
+meta def enum_assoc_subexpr' (fn : expr) : expr → tactic (dlist expr)
+| e :=
+dlist.singleton e <$ (match_fn fn e >> guard (¬ e.has_var)) <|>
+expr.mfoldl (λ es e', (++ es) <$> enum_assoc_subexpr' e') dlist.empty e
+
+meta def enum_assoc_subexpr (fn e : expr) : tactic (list expr) :=
+dlist.to_list <$> enum_assoc_subexpr' fn e
+
+meta def mk_assoc_instance (fn : expr) : tactic expr :=
+do t ← mk_mapp ``is_associative [none,fn],
+   inst ← prod.snd <$> solve_aux t assumption <|>
+     (mk_instance t >>= assertv `_inst t) <|>
+     fail format!"{fn} is not associative",
+   mk_mapp ``is_associative.assoc [none,fn,inst]
+
+meta def assoc_rewrite (h e : expr) (opt_assoc : option expr := none) :
+  tactic (expr × expr × list expr) :=
+do (t,vs) ← infer_type h >>= fill_args,
+   (lhs,rhs) ← match_eq t,
+   let fn  := lhs.app_fn.app_fn,
+   es ← enum_assoc_subexpr fn e,
+   assoc ← match opt_assoc with
+           | none := mk_assoc_instance fn
+           | (some assoc) := pure assoc
+           end,
+   (_,p) ← mfirst (assoc_rewrite_intl assoc $ h.mk_app vs) es,
+   (e',p',_) ← tactic.rewrite p e,
+   pure (e',p',vs)
+
+meta def assoc_rewrite_target (h : expr) (opt_assoc : option expr :=  none) :
+  tactic unit :=
+do tgt ← target,
+   (tgt',p,_) ← assoc_rewrite h tgt opt_assoc,
+   replace_target tgt' p
+
+meta def assoc_rewrite_hyp (h hyp : expr) (opt_assoc : option expr := none) :
+  tactic expr :=
+do tgt ← infer_type hyp,
+   (tgt',p,_) ← assoc_rewrite h tgt opt_assoc,
+   replace_hyp hyp tgt' p
+
+example : ∀ x y z a b c : ℕ, true :=
+begin
+ intros,
+ have : ∀ y, x + (y + z) = 3 + y, admit,
+ have : a + (b + x) + y + (z + b + c) ≤ 0,
+ (do this ← get_local `this,
+     tgt ← to_expr ```(a + (b + x) + y + (z + b + c)),
+     assoc_rewrite_target this ),
+ guard_target a + b + 3 + y + b + c ≤ 0,
+ admit,
+ trivial
+end
+
+namespace interactive
+
+open lean.parser interactive interactive.types tactic
+
+private meta def assoc_rw_goal (rs : list rw_rule) : tactic unit :=
+rs.mmap' $ λ r, do
+ save_info r.pos,
+ eq_lemmas ← get_rule_eqn_lemmas r,
+ orelse'
+   (do e ← to_expr' r.rule, assoc_rewrite_target e)
+   (eq_lemmas.mfirst $ λ n, do e ← mk_const n, assoc_rewrite_target e)
+   (eq_lemmas.empty)
+
+private meta def uses_hyp (e : expr) (h : expr) : bool :=
+e.fold ff $ λ t _ r, r || to_bool (t = h)
+
+private meta def assoc_rw_hyp : list rw_rule → expr → tactic unit
+| []      hyp := skip
+| (r::rs) hyp := do
+  save_info r.pos,
+  eq_lemmas ← get_rule_eqn_lemmas r,
+  orelse'
+    (do e ← to_expr' r.rule, when (not (uses_hyp e hyp)) $ assoc_rewrite_hyp e hyp >>= assoc_rw_hyp rs)
+    (eq_lemmas.mfirst $ λ n, do e ← mk_const n, assoc_rewrite_hyp e hyp >>= assoc_rw_hyp rs)
+    (eq_lemmas.empty)
+
+
+private meta def assoc_rw_core (rs : parse rw_rules) (loca : parse location) : tactic unit :=
+match loca with
+| loc.wildcard := loca.try_apply (assoc_rw_hyp rs.rules) (assoc_rw_goal rs.rules)
+| _            := loca.apply (assoc_rw_hyp rs.rules) (assoc_rw_goal rs.rules)
+end >> try (reflexivity)
+    >> (returnopt rs.end_pos >>= save_info <|> skip)
+
+meta def assoc_rewrite (q : parse rw_rules) (l : parse location) : tactic unit :=
+propagate_tags (assoc_rw_core q l)
+
+meta def assoc_rw (q : parse rw_rules) (l : parse location) : tactic unit :=
+propagate_tags (assoc_rw_core q l)
+
+end interactive
+end tactic

--- a/tactic/ring.lean
+++ b/tactic/ring.lean
@@ -66,16 +66,6 @@ theorem horner_horner {α} [comm_semiring α] (a₁ x n₁ n₂ b n')
   @horner α _ (horner a₁ x n₁ 0) x n₂ b = horner a₁ x n' b :=
 by simp [h.symm, horner, pow_add, mul_assoc]
 
-meta def refl_conv (e : expr) : tactic (expr × expr) :=
-do p ← mk_eq_refl e, return (e, p)
-
-meta def trans_conv (t₁ t₂ : expr → tactic (expr × expr)) (e : expr) :
-  tactic (expr × expr) :=
-(do (e₁, p₁) ← t₁ e,
-  (do (e₂, p₂) ← t₂ e₁,
-    p ← mk_eq_trans p₁ p₂, return (e₂, p)) <|>
-  return (e₁, p₁)) <|> t₂ e
-
 meta def eval_horner (c : cache) (a x n b : expr) : tactic (expr × expr) :=
 do d ← destruct a, match d with
 | const q := if q = 0 then

--- a/tests/tactics.lean
+++ b/tests/tactics.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon
 -/
 import tactic data.set.lattice data.prod
+       tactic.rewrite
 
 section solve_by_elim
 example {a b : Prop} (h₀ : a → b) (h₁ : a) : b :=
@@ -533,3 +534,19 @@ begin
 end
 
 end h_generalize
+
+section assoc_rw
+
+variables x y z a b c : ℕ
+variables h₀ : ∀ (y : ℕ), x + (y + z) = 3 + y
+variables h₁ : a + (b + x) + y + (z + b + a) ≤ 0
+variables h₂ : y + b + c = y + b + a
+include h₀ h₁ h₂
+example : a + (b + x) + y + (z + b + c) ≤ 0 :=
+by { assoc_rw [h₀,h₂] at *,
+     guard_hyp _inst := is_associative ℕ has_add.add,
+       -- keep a local instance of is_associative to cache
+       -- type class queries
+     exact h₁ }
+
+end assoc_rw


### PR DESCRIPTION
…osets

Automated the construction of instances on quotient types.

This might be worth using if you use more than groups on quotient types.

TO CONTRIBUTORS:

Make sure you have:

 * [x] reviewed and applied the coding style: [coding](./docs/style.md), [naming](./docs/naming.md)
 * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](./docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](./tests/tactics.lean)
  * [x] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

For reviewers: [code review check list](./docs/code-review.md)
